### PR TITLE
Sign error in collection function

### DIFF
--- a/photovoltaic/cell.py
+++ b/photovoltaic/cell.py
@@ -188,20 +188,26 @@ def cell_params(V, I):
     return Voc, Isc, FF, Vmp, Imp
 
 
-def collection(x, thickness, S, L, D):
+def collection(x, thickness, s, l, d):
     """Returns the collection probability (unit 0 to 1) at a distance x (cm) from the junction.
     Where: thickness is the layer thickness (cm),
-    S is the surface recombination velocity (cm/s),
-    L is the minority carrier diffusion length (cm) and
-    D is the diffusivity (cm²/Vs)
+    s is the surface recombination velocity (cm/s),
+    l is the minority carrier diffusion length (cm) and
+    d is the diffusivity (cm²/Vs)
     """
-    hypSin_xL = np.sinh(-x / L)
-    hypCos_xL = np.cosh(-x / L)
-    hypSin_WL = np.sinh(-thickness / L)
-    hypCos_WL = np.cosh(-thickness / L)
-    num = S * L / D * hypCos_WL + hypSin_WL
-    denom = S * L / D * hypSin_WL + hypCos_WL
-    return (hypCos_xL - num / denom * hypSin_xL)
+    
+    cosh_xl = np.cosh(x/l)
+    cosh_wl = np.cosh(thickness/l)
+    sinh_xl = np.sinh(x/l)
+    sinh_wl = np.sinh(thickness/l)
+    
+    num = s*l/d*cosh_wl + sinh_wl
+    den = s*l/d*sinh_wl + cosh_wl
+    
+    cp = cosh_xl - (num/den)*sinh_xl
+    
+    return cp
+                 
 
 
 def genfcurrent(current):


### PR DESCRIPTION
Noticed when creating collection probability profiles that increasing surface recombination velocity S was increasing collection probability, rather than the expected effect of increased S resulting in decreased collection.

Compared to the CP eqn at [pveducation](https://www.pveducation.org/pvcdrom/solar-cell-operation/collection-probability), the function has negative signs in the trig functions. The slider for S at pveducation has the expected effect on CP, so not sure where the error got introduced. See below graphs of CP for various values of S before and after the fix.

![image](https://user-images.githubusercontent.com/96535942/164792664-d66b6e21-3898-40e0-8aaf-37e3ccbac286.png)


![image](https://user-images.githubusercontent.com/96535942/164792688-8672b8d2-1fc4-4e13-9e0d-53f94618e99f.png)
